### PR TITLE
Fix project license and list third-party licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,23 @@
 ssr audio effect based on DISTRHO Plugin Framework (DPF)
 Copyright (C) 2020 Jean Pierre Cimalando <jpcima@protonmail.com>
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,44 @@
 A sympathetic string resonator
 
 https://en.wikipedia.org/wiki/String_resonance
+
+
+
+## Licenses
+
+ssr is licenced under the BSD-2-Clause license. Please see the file
+[LICENSE] for details.
+
+ssr incorporates code and resources from the following projects with their own
+licensing:
+
+* [Blink] font is used under the BSD-2-Clause license. Please see the file
+  [COPYING](thirdparty/blink/COPYING) for details.
+
+* [cpuid] font is used under the BSD-3-Clause license. Please see the file
+  [LICENSE.rst](thirdparty/cpuid/LICENSE.rst) for details.
+
+* [DPF] font is used under the ISC license. Please see the file
+  [LICENSE](dpf/LICENSE) for details.
+
+* The [Liberation] font is used under the OFL-1.1 license. Please see the file
+  [LICENSE](resources/fonts/liberation/LICENSE) for details.
+
+* [fontstash] is used under the Zlib license. Please see the file
+  [LICENSE.txt](thirdparty/fontstash/LICENSE.txt) for details.
+
+* [sfizz] is used under the BSD-2-Clause license. Please see the file
+  [LICENSE](libs/strings/LICENSE) for details.
+
+* [stb] font is used under the MIT license. Please see the file
+  [LICENSE](thirdparty/stb/LICENSE) for details.
+
+
+[Blink]: https://chromium.googlesource.com/chromium/blink/
+[cpuid]: https://github.com/steinwurf/cpuid
+[DPF]: https://github.com/DISTRHO/DPF
+[fontstash]: https://github.com/memononen/fontstash
+[Liberation]: https://github.com/liberationfonts/liberation-fonts
+[LICENSE]: ./LICENSE
+[sfizz]: https://github.com/sfztools/sfizz
+[stb]: https://github.com/nothings/stb

--- a/libs/strings/Config.h
+++ b/libs/strings/Config.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once

--- a/libs/strings/Debug.h
+++ b/libs/strings/Debug.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once

--- a/libs/strings/LICENSE
+++ b/libs/strings/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2021-2023, sfizz contributors (detailed in AUTHORS.md)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/libs/strings/LeakDetector.h
+++ b/libs/strings/LeakDetector.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once

--- a/libs/strings/ResonantArray.cpp
+++ b/libs/strings/ResonantArray.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "ResonantArray.h"

--- a/libs/strings/ResonantArray.h
+++ b/libs/strings/ResonantArray.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once

--- a/libs/strings/ResonantArrayAVX.cpp
+++ b/libs/strings/ResonantArrayAVX.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "ResonantArrayAVX.h"

--- a/libs/strings/ResonantArrayAVX.h
+++ b/libs/strings/ResonantArrayAVX.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once

--- a/libs/strings/ResonantArraySSE.cpp
+++ b/libs/strings/ResonantArraySSE.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "ResonantArraySSE.h"

--- a/libs/strings/ResonantArraySSE.h
+++ b/libs/strings/ResonantArraySSE.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once

--- a/libs/strings/ResonantString.cpp
+++ b/libs/strings/ResonantString.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 /**

--- a/libs/strings/ResonantString.h
+++ b/libs/strings/ResonantString.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 /**

--- a/libs/strings/ResonantStringAVX.cpp
+++ b/libs/strings/ResonantStringAVX.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 /**

--- a/libs/strings/ResonantStringAVX.h
+++ b/libs/strings/ResonantStringAVX.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 /**

--- a/libs/strings/ResonantStringSSE.cpp
+++ b/libs/strings/ResonantStringSSE.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 /**

--- a/libs/strings/ResonantStringSSE.h
+++ b/libs/strings/ResonantStringSSE.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 /**

--- a/libs/strings/SIMDConfig.h
+++ b/libs/strings/SIMDConfig.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 // This code is part of the sfizz library and is licensed under a BSD 2-clause
-// license. You should have receive a LICENSE.md file along with the code.
+// license. You should have receive a LICENSE file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once


### PR DESCRIPTION
I assume that the project license was meant to be the BSD-2-Clause license, since this is what is stated [in the plugin info](https://github.com/jpcima/ssr/blob/e1999dabbf3290e7a194752208f3cea60005663b/plugins/ssr/Pluginssr.h#L42) and it's also the license of the sfizz code this plugin is based on. The top-level license file, though, contained the text of the ISC license. I assumed this was copied from DPF and just overlooked.

* fix: change license text from ISC to correct BSD-2-Clause
* fix: add sfizz license file and fix references in source files
* feat: state project license in readme
* feat: list all used third-party projects and their licenses in readme
