### PR TITLE
fix: off-by-one error in max. string number calculation in StringEditor widget

### DIFF
--- a/plugins/ssr/ui/StringsEditor.cpp
+++ b/plugins/ssr/ui/StringsEditor.cpp
@@ -160,8 +160,7 @@ void StringsEditor::editStringByMouse(Point<int> pos)
 {
     int32_t stringNum = std::lrint(xPosToStringNum(pos.getX()));
     const uint32_t numStrings = fStringValues.size();
-
-    stringNum = std::min(numStrings, (uint32_t)std::max(0, stringNum));
+    stringNum = std::min(numStrings - 1, (uint32_t)std::max(0, stringNum));
 
     const float min = fStringValueMin;
     const float max = fStringValueMax;


### PR DESCRIPTION
This caused a crash of the plugin UI when dragging the mouse past the right boundary of one of the `StringEditor` widgets and back into the widget area again.

```
/usr/include/c++/13.2.1/bits/stl_vector.h:1125: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = float; _Alloc = std::allocator<float>; reference = float&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

In that case the the code calculated a `stringNum = 88` from the mouse x position, which is out of bounds for the `fStringValues` array.
