### PR TITLE
Update DPF and Cairo UI

### DIFF
--- a/plugins/ssr/Pluginssr.cpp
+++ b/plugins/ssr/Pluginssr.cpp
@@ -52,7 +52,7 @@ void Pluginssr::initParameter(uint32_t index, Parameter &parameter)
         parameter.symbol = "depth";
         parameter.name = "Depth";
         parameter.ranges = ParameterRanges(1.0, 0.0, 1.0);
-        parameter.hints = kParameterIsAutomable|kParameterIsLogarithmic;
+        parameter.hints = kParameterIsAutomatable|kParameterIsLogarithmic;
         break;
     }
 }

--- a/plugins/ssr/UIssr.cpp
+++ b/plugins/ssr/UIssr.cpp
@@ -26,18 +26,15 @@ UIssr::UIssr()
     fFontEngine.reset(fe);
     fe->addFont("regular", fontRegular, sizeof(fontRegular));
 
-    StringsEditor *ed;
-
-    ed = makeSubwidget<StringsEditor>(this);
-    fGainEdit = ed;
-    ed->setAbsolutePos(20, 40);
-    ed->setSize(560, 120);
-    ed->setBarColor(Color(0.95f, 0.45f, 0.0f));
+    fGainEdit = new StringsEditor(this);
+    fGainEdit->setAbsolutePos(20, 40);
+    fGainEdit->setSize(560, 120);
+    fGainEdit->setBarColor(Color(0.95f, 0.45f, 0.0f));
     if (kGainsEditLogarithmic)
-        ed->setStringValueBounds(kGainMinDb, kGainMaxDb);
+        fGainEdit->setStringValueBounds(kGainMinDb, kGainMaxDb);
     else
-        ed->setStringValueBounds(gainLog2Lin(kGainMinDb), gainLog2Lin(kGainMaxDb));
-    ed->OnStringValueChanged = [this](uint32_t stringNum, float value) {
+        fGainEdit->setStringValueBounds(gainLog2Lin(kGainMinDb), gainLog2Lin(kGainMaxDb));
+    fGainEdit->OnStringValueChanged = [this](uint32_t stringNum, float value) {
         if (kGainsEditLogarithmic)
             fState->gains[stringNum] = gainLog2Lin(value);
         else
@@ -45,24 +42,20 @@ UIssr::UIssr()
         fMustResendState = true;
     };
 
-    ed = makeSubwidget<StringsEditor>(this);
-    fTimeEdit = ed;
-    ed->setAbsolutePos(20, 200);
-    ed->setSize(560, 120);
-    ed->setBarColor(Color(0.0f, 0.95f, 0.45f));
-    ed->setStringValueBounds(kFeedbackTimeMin, kFeedbackTimeMax);
-    ed->OnStringValueChanged = [this](uint32_t stringNum, float value) {
+    fTimeEdit = new StringsEditor(this);
+    fTimeEdit->setAbsolutePos(20, 200);
+    fTimeEdit->setSize(560, 120);
+    fTimeEdit->setBarColor(Color(0.0f, 0.95f, 0.45f));
+    fTimeEdit->setStringValueBounds(kFeedbackTimeMin, kFeedbackTimeMax);
+    fTimeEdit->OnStringValueChanged = [this](uint32_t stringNum, float value) {
         fState->feedbackTimes[stringNum] = value;
         fMustResendState = true;
     };
 
-    Slider *sl;
-
-    sl = makeSubwidget<Slider>(this, *fe);
-    fDepthSlider = sl;
-    sl->setAbsolutePos(20, 360);
-    sl->setSize(560, 20);
-    sl->ValueChangedCallback = [this](float value) {
+    fDepthSlider = new Slider(this, *fe);
+    fDepthSlider->setAbsolutePos(20, 360);
+    fDepthSlider->setSize(560, 20);
+    fDepthSlider->ValueChangedCallback = [this](float value) {
         setParameterValue(Pluginssr::pidSustainAmount, value);
     };
 
@@ -144,9 +137,9 @@ void UIssr::uiReshape(uint width, uint height)
 /**
   A function called to draw the view contents.
 */
-void UIssr::onDisplay()
+void UIssr::onCairoDisplay(const CairoGraphicsContext& context)
 {
-    cairo_t *cr = getParentWindow().getGraphicsContext().cairo;
+    cairo_t* const cr = context.handle;
 
     cairo_set_source_rgb(cr, 0, 0, 0);
     cairo_paint(cr);
@@ -172,54 +165,6 @@ void UIssr::onDisplay()
         kAlignTopLeft|kAlignInside);
 }
 
-
-// -----------------------------------------------------------------------
-// Optional widget callbacks; return true to stop event propagation, false otherwise.
-
-/**
-  A function called when a key is pressed or released.
-*/
-bool UIssr::onKeyboard(const KeyboardEvent &ev)
-{
-    return false;
-    (void)ev;
-}
-
-/**
-  A function called when a special key is pressed or released.
-*/
-bool UIssr::onSpecial(const SpecialEvent &ev)
-{
-    return false;
-    (void)ev;
-}
-
-/**
-  A function called when a mouse button is pressed or released.
-*/
-bool UIssr::onMouse(const MouseEvent &ev)
-{
-    return false;
-    (void)ev;
-}
-
-/**
-  A function called when the mouse pointer moves.
-*/
-bool UIssr::onMotion(const MotionEvent &ev)
-{
-    return false;
-    (void)ev;
-}
-
-/**
-  A function called on scrolling (e.g. mouse wheel or track pad).
-*/
-bool UIssr::onScroll(const ScrollEvent &ev)
-{
-    return false;
-    (void)ev;
-}
 
 // -----------------------------------------------------------------------
 

--- a/plugins/ssr/UIssr.h
+++ b/plugins/ssr/UIssr.h
@@ -21,32 +21,17 @@ protected:
     void uiIdle() override;
     void uiReshape(uint width, uint height) override;
 
-    void onDisplay() override;
-
-    bool onKeyboard(const KeyboardEvent &ev) override;
-    bool onSpecial(const SpecialEvent &ev) override;
-    bool onMouse(const MouseEvent &ev) override;
-    bool onMotion(const MotionEvent &ev) override;
-    bool onScroll(const ScrollEvent &ev) override;
+    void onCairoDisplay(const CairoGraphicsContext& context) override;
 
 private:
     void updateUiState();
 
 private:
-    template <class W, class... A>
-    W *makeSubwidget(A &&... args)
-    {
-        W *w = new W(std::forward<A>(args)...);
-        fSubWidgets.push_back(std::unique_ptr<Widget>(w));
-        return w;
-    }
-
-    std::vector<std::unique_ptr<Widget>> fSubWidgets;
     std::unique_ptr<FontEngine> fFontEngine;
 
-    StringsEditor *fGainEdit = nullptr;
-    StringsEditor *fTimeEdit = nullptr;
-    Slider *fDepthSlider = nullptr;
+    ScopedPointer<StringsEditor> fGainEdit;
+    ScopedPointer<StringsEditor> fTimeEdit;
+    ScopedPointer<Slider> fDepthSlider;
 
     std::unique_ptr<SsrState> fState;
     bool fMustResendState = false;

--- a/plugins/ssr/meta/DistrhoPluginInfo.h
+++ b/plugins/ssr/meta/DistrhoPluginInfo.h
@@ -14,6 +14,7 @@
 #define DISTRHO_PLUGIN_URI "http://jpcima.sdf1.org/plugins/ssr"
 
 #define DISTRHO_PLUGIN_HAS_UI 1
+#define DISTRHO_UI_USE_CAIRO 1
 #define DISTRHO_UI_USE_NANOVG 0
 
 #define DISTRHO_PLUGIN_IS_RT_SAFE 1

--- a/plugins/ssr/ui/Slider.cpp
+++ b/plugins/ssr/ui/Slider.cpp
@@ -1,13 +1,19 @@
-#include "Slider.h"
 #include "Window.hpp"
 #include "Cairo.hpp"
+#include "Slider.h"
 #include "ui/FontEngine.h"
 #include "ui/Geometry.h"
 #include "ui/Cairo++.h"
 
 ///
-Slider::Slider(Widget *group, FontEngine &fontEngine)
-    : Widget(group),
+Slider::Slider(TopLevelWidget* const parent, FontEngine &fontEngine)
+    : CairoSubWidget(parent),
+      fFontEngine(fontEngine)
+{
+}
+
+Slider::Slider(SubWidget* const parent, FontEngine &fontEngine)
+    : CairoSubWidget(parent),
       fFontEngine(fontEngine)
 {
 }
@@ -45,7 +51,7 @@ void Slider::setNumSteps(unsigned numSteps)
 bool Slider::onMouse(const MouseEvent &event)
 {
     DGL::Size<uint> wsize = getSize();
-    DGL::Point<int> mpos = event.pos;
+    DGL::Point<double> mpos = event.pos;
 
     if (!fIsDragging && event.press && event.button == 1) {
         bool insideX = mpos.getX() >= 0 && (unsigned)mpos.getX() < wsize.getWidth();
@@ -72,7 +78,7 @@ bool Slider::onMouse(const MouseEvent &event)
 bool Slider::onMotion(const MotionEvent &event)
 {
     DGL::Size<uint> wsize = getSize();
-    DGL::Point<int> mpos = event.pos;
+    DGL::Point<double> mpos = event.pos;
 
     if (fIsDragging) {
         double fill = mpos.getX() / (double)wsize.getWidth();
@@ -88,7 +94,7 @@ bool Slider::onMotion(const MotionEvent &event)
 bool Slider::onScroll(const ScrollEvent &event)
 {
     DGL::Size<uint> wsize = getSize();
-    DGL::Point<int> mpos = event.pos;
+    DGL::Point<double> mpos = event.pos;
 
     bool inside =
         mpos.getX() >= 0 && mpos.getY() >= 0 &&
@@ -103,9 +109,9 @@ bool Slider::onScroll(const ScrollEvent &event)
     return false;
 }
 
-void Slider::onDisplay()
+void Slider::onCairoDisplay(const CairoGraphicsContext& context)
 {
-    cairo_t *cr = getParentWindow().getGraphicsContext().cairo;
+    cairo_t* const cr = context.handle;
     FontEngine &fe = fFontEngine;
 
     //

--- a/plugins/ssr/ui/Slider.h
+++ b/plugins/ssr/ui/Slider.h
@@ -1,12 +1,13 @@
 #pragma once
-#include "Widget.hpp"
+#include "Cairo.hpp"
 #include <string>
 #include <functional>
 class FontEngine;
 
-class Slider : public Widget {
+class Slider : public CairoSubWidget {
 public:
-    Slider(Widget *group, FontEngine &fontEngine);
+    Slider(SubWidget* const parent, FontEngine &fontEngine);
+    Slider(TopLevelWidget* const parent, FontEngine &fontEngine);
 
     double value() const noexcept { return fValue; }
     void setValue(double value);
@@ -17,13 +18,14 @@ public:
     void setValueBounds(double v1, double v2);
     void setNumSteps(unsigned numSteps);
 
+    std::function<void(double)> ValueChangedCallback;
+    std::function<std::string(double)> FormatCallback;
+
+protected:
     bool onMouse(const MouseEvent &event) override;
     bool onMotion(const MotionEvent &event) override;
     bool onScroll(const ScrollEvent &event) override;
-    void onDisplay() override;
-
-    std::function<void(double)> ValueChangedCallback;
-    std::function<std::string(double)> FormatCallback;
+    void onCairoDisplay(const CairoGraphicsContext& context) override;
 
 private:
     double clampToBounds(double value);

--- a/plugins/ssr/ui/StringsEditor.cpp
+++ b/plugins/ssr/ui/StringsEditor.cpp
@@ -1,10 +1,17 @@
-#include "StringsEditor.h"
+#include <algorithm>
 #include "Window.hpp"
 #include "Cairo.hpp"
-#include <algorithm>
+#include "StringsEditor.h"
 
-StringsEditor::StringsEditor(Widget *group)
-    : Widget(group),
+StringsEditor::StringsEditor(TopLevelWidget *group)
+    : CairoSubWidget(group),
+      fBarColor(0.95f, 0.45f, 0.0f)
+{
+    fStringValues.resize(88);
+}
+
+StringsEditor::StringsEditor(SubWidget *group)
+    : CairoSubWidget(group),
       fBarColor(0.95f, 0.45f, 0.0f)
 {
     fStringValues.resize(88);
@@ -65,9 +72,9 @@ void StringsEditor::setStringValueBounds(float min, float max)
     repaint();
 }
 
-void StringsEditor::onDisplay()
+void StringsEditor::onCairoDisplay(const CairoGraphicsContext& context)
 {
-    cairo_t *cr = getParentWindow().getGraphicsContext().cairo;
+    cairo_t* const cr = context.handle;
     cairo_save(cr);
 
     const int w = getWidth();
@@ -114,8 +121,8 @@ bool StringsEditor::onMouse(const MouseEvent &event)
     const int h = getHeight();
 
     if (event.button == 1 && event.press) {
-        int mx = event.pos.getX();
-        int my = event.pos.getY();
+        double mx = event.pos.getX();
+        double my = event.pos.getY();
         if (mx >= 0 && mx < w && my >= 0 && my < h) {
             fDragging = true;
             fLastStringMouseEdited = -1;
@@ -156,7 +163,7 @@ double StringsEditor::xPosToStringNum(double x) const
     return x / xsep - 1;
 }
 
-void StringsEditor::editStringByMouse(Point<int> pos)
+void StringsEditor::editStringByMouse(Point<double> pos)
 {
     int32_t stringNum = std::lrint(xPosToStringNum(pos.getX()));
     const uint32_t numStrings = fStringValues.size();

--- a/plugins/ssr/ui/StringsEditor.h
+++ b/plugins/ssr/ui/StringsEditor.h
@@ -1,12 +1,13 @@
 #pragma once
-#include "Widget.hpp"
+#include "Cairo.hpp"
 #include "Color.hpp"
 #include <functional>
 #include <vector>
 
-class StringsEditor : public Widget {
+class StringsEditor : public CairoSubWidget {
 public:
-    explicit StringsEditor(Widget *group);
+    explicit StringsEditor(TopLevelWidget *group);
+    explicit StringsEditor(SubWidget *group);
 
     Color barColor() const { return fBarColor; }
     void setBarColor(Color color);
@@ -22,7 +23,7 @@ public:
     std::function<void(uint32_t, float)> OnStringValueChanged;
 
 protected:
-    void onDisplay() override;
+    void onCairoDisplay(const CairoGraphicsContext& context) override;
     bool onMouse(const MouseEvent &event) override;
     bool onMotion(const MotionEvent &event) override;
 
@@ -30,7 +31,7 @@ private:
     double stringNumToXPos(double s) const;
     double xPosToStringNum(double x) const;
 
-    void editStringByMouse(Point<int> pos);
+    void editStringByMouse(Point<double> pos);
 
 private:
     std::vector<float> fStringValues;

--- a/plugins/ssr/ui/TextLabel.cpp
+++ b/plugins/ssr/ui/TextLabel.cpp
@@ -2,8 +2,14 @@
 #include "Window.hpp"
 #include "Cairo.hpp"
 
-TextLabel::TextLabel(Widget *group, FontEngine &fontEngine)
-    : Widget(group),
+TextLabel::TextLabel(TopLevelWidget *group, FontEngine &fontEngine)
+    : CairoSubWidget(group),
+      fFontEngine(fontEngine)
+{
+}
+
+TextLabel::TextLabel(SubWidget *group, FontEngine &fontEngine)
+    : CairoSubWidget(group),
       fFontEngine(fontEngine)
 {
 }
@@ -35,9 +41,9 @@ void TextLabel::setAlignment(int align)
     repaint();
 }
 
-void TextLabel::onDisplay()
+void TextLabel::onCairoDisplay(const CairoGraphicsContext& context)
 {
-    cairo_t *cr = getParentWindow().getGraphicsContext().cairo;
+    cairo_t* const cr = context.handle;
     FontEngine &fe = fFontEngine;
 
     Rect box{0, 0, (int)getWidth(), (int)getHeight()};

--- a/plugins/ssr/ui/TextLabel.h
+++ b/plugins/ssr/ui/TextLabel.h
@@ -1,10 +1,11 @@
 #pragma once
-#include "Widget.hpp"
+#include "Cairo.hpp"
 #include "ui/FontEngine.h"
 
-class TextLabel : public Widget {
+class TextLabel : public CairoSubWidget {
 public:
-    TextLabel(Widget *group, FontEngine &fontEngine);
+    TextLabel(TopLevelWidget *group, FontEngine &fontEngine);
+    TextLabel(SubWidget *group, FontEngine &fontEngine);
 
     const Font &font() const { return fFont; };
     void setFont(const Font &font);
@@ -16,7 +17,7 @@ public:
     void setAlignment(int align);
 
 protected:
-    void onDisplay() override;
+    void onCairoDisplay(const CairoGraphicsContext& context) override;
 
 private:
     FontEngine &fFontEngine;


### PR DESCRIPTION

* feat: update DPF submodule to upstream commit 63dfb761.
* fix: adapt plugin code to DPF / DGL API changes:
    * Defined `DISTRHO_UI_USE_CAIRO 1` in plugin config, making `UI` inherit from Cairo UI.
    * Changed base class of custom widgets to `CairoSubWidget` and added missing constructors for instantiation passing `TopLevelWidget` as parent.
    * Changed includes to `Cairo.hpp` accordingly.
    * Changed widgets to use `onCairoDisplay` instead of `onDisplay` callback to get easy access to `CairoGraphicsContext` and `cairo_t` handle.
    * Marked callback methods in all custom widget classes as `protected`.
    * Removed superfluous event handler callbacks from class `UIssr`, they were doing nothing.
    * Adapted to change of `pos` member of `*Event` classes from `Point<int>` to `Point<double>`.
    * Replaced `kParameterIsAutomable` with `kParameterIsAutomatable`.
